### PR TITLE
fix bug with version 6d

### DIFF
--- a/lib/Template/Classic.pm6
+++ b/lib/Template/Classic.pm6
@@ -65,7 +65,7 @@ my class Actions
 {
     method TOP($/)
     {
-        make qq｢lazy gather \{ {$<part>.map({.made ~ “\n”}).join} \}｣;
+        make qq｢gather \{ {$<part>.map({.made ~ “\n”}).join} \}｣;
     }
 
     method text($/)


### PR DESCRIPTION
I'm running rakudo version 6d. The example in synopsis was just outputting three dots. Based on the description of the existing bug, I was able to guess at the problem and fix the issue by removing the `lazy` keyword. I'm new to raku so no idea if this is the proper fix.